### PR TITLE
User generated folder

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -11,28 +11,34 @@ function parseArgumentsIntoOptions(rawArgs){
             '--install': Boolean,
             '-g': '--git',
             '-y': '--yes',
-            '-i': '--install'
+            '-i': '--install',
         },
         {
             argv: rawArgs.slice(2),
 
         }
     )
+    // // For Testing remove
+    // console.log(rawArgs)
     return {
         skipPrompts : args['--yes'] || false,
         git : args['--git'] || false,
         template: args._[0],
-        runInstall : args['--install'] || false
+        runInstall : args['--install'] || false,
+        projectName : args._[1]
+        
 
     }
 }
 
 async function promptForMissingOptions(options){
-    const defaultTemplate = 'Express';
+    const defaultTemplate = 'Test';
+    const defaultName = 'my-app';
     if (options.skipPrompts){
         return{
             ...options,
-            template: options.template || defaultTemplate
+            template: options.template || defaultTemplate,
+            projectName : options.projectName || defaultName
         }
     }
 
@@ -45,6 +51,13 @@ async function promptForMissingOptions(options){
             // Add Templates here
             choices :['Test'],
             default : defaultTemplate,
+        })
+    }
+    if(!options.projectName){
+        questions.push({
+            name : 'Project Name',
+            message: 'Enter your project name: ',
+            default : defaultName
         })
     }
 
@@ -61,13 +74,17 @@ async function promptForMissingOptions(options){
     return{
         ...options,
         template : options.template || answers.template,
+        projectName: options.projectName || answers.template,
         git : options.git || answers.git,
     }
 }
 
 export async function cli(args){
     let options = parseArgumentsIntoOptions(args);
+    // For Testing remove
+    // console.log(options)
     options = await promptForMissingOptions(options)
     await createProject(options)
-    console.log(options)
+    // // For Testing remove
+    // console.log(options)
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,38 +2,51 @@ import chalk from 'chalk';
 import fs from 'fs';
 import ncp from 'ncp';
 import path from 'path';
-import {promisify} from 'util';
+import { promisify } from 'util';
 import execa from 'execa'
 import Listr from 'listr'
-import {projectInstall} from 'pkg-install'
+import { projectInstall } from 'pkg-install'
 
 // check for r+w access
 const access = promisify(fs.access)
 // recursive file copy
 const copy = promisify(ncp);
 
-async function copyTemplateFiles(options){
+async function copyTemplateFiles(options) {
+    // Create App Folder 
+    const newPath = `${options.targetDirectory}\\${options.projectName}`
+
+    try {
+        fs.mkdirSync(newPath)
+        console.log('App %s has been created!', chalk.bold.green(`${options.projectName}`))
+    } catch (err) {
+        console.log(err)
+    }
+    
+    options.targetDirectory = newPath
     return copy(options.templateDirectory, options.targetDirectory, {
         // Prevent file overwrite when copying
-        clobber : false
+        clobber: false
     })
 }
 
-async function initGit(options){
+async function initGit(options) {
     const result = await execa('git', ['init'], {
-        cwd : options.targetDirectory,
+        cwd: options.targetDirectory,
     })
-    if (result.failed){
+    if (result.failed) {
         return Promise.reject(new Error('Failed to initialize Git'));
     }
     return;
 }
 
-export async function createProject(options){
-    options ={
+export async function createProject(options) {
+    options = {
         ...options,
-        targetDirectory : options.targetDirectory || process.cwd(),
+        targetDirectory: options.targetDirectory || process.cwd(),
+        
     }
+
 
     let currentFileUrl = import.meta.url
     // Fix for the double C:/C:/
@@ -44,11 +57,11 @@ export async function createProject(options){
         options.template.toLowerCase()
     );
     options.templateDirectory = templateDir;
-    
-    try{
+
+    try {
         await access(templateDir, fs.constants.R_OK)
     }
-    catch(err){
+    catch (err) {
         console.log(templateDir)
         console.error('%s Invalid template name', chalk.red.bold("Error"))
         process.exit(1)
@@ -57,25 +70,25 @@ export async function createProject(options){
     const tasks = new Listr([
         {
             title: 'Copying Project files',
-            task : () => copyTemplateFiles(options)
+            task: () => copyTemplateFiles(options)
         },
         {
-            title : 'Initialize Git',
-            task : () => initGit(options),
-            enabled : () => options.git
+            title: 'Initialize Git',
+            task: () => initGit(options),
+            enabled: () => options.git
         },
         {
-            title : 'Install dependecies',
-            task : () => projectInstall({
-                cwd : options.targetDirectory,
+            title: 'Install dependecies',
+            task: () => projectInstall({
+                cwd: options.targetDirectory,
             }),
-            skip : () => !options.runInstall ? 'Pass --install or --i to automatically install dependecies'
-                                             : undefined
+            skip: () => !options.runInstall ? 'Pass --install or --i to automatically install dependecies'
+                : undefined
         }
 
     ]);
 
-    await  tasks.run()
+    await tasks.run()
 
     console.log('%s Project ready', chalk.green.bold('DONE'))
     return true;


### PR DESCRIPTION
User can now pass argument to create folder

`create-basic-app {template} my-app-name`

Bug --
if the user just runs the `create-basic-app `
And is prompted to enter an app name
The Project name defaults to Test (regardless of input)